### PR TITLE
qeio: sometimes the 'highest occupied' line in pw.out has only one value

### DIFF
--- a/qeutil/qeio.py
+++ b/qeutil/qeio.py
@@ -185,7 +185,8 @@ def read_quantumespresso_textoutput(filename, verbose=False):
 
             if l.rfind('highest occupied') > -1 :
                 t = l.split()
-                Results['HOL'] = float(t[-2])
+                try: Results['HOL'] = float(t[-2]) # sometimes this line has only 1 value
+                except ValueError: pass
                 Results['LUL'] = float(t[-1])
 
             if l.rfind('magnetization') > -1:


### PR DESCRIPTION
In order to cope with missing information in 'highest occupied' line, a try except is added to avoid the Error.
This affects few calculations, but is real e.g. with some materials (e.g. MgO) and QE 5.1
The HOL and LUL dict entries are only used further when plotting bands, and this read error should not block the reading procedure.