### PR TITLE
qeio.py: handle case with missing xml/DFT/LDA_PLUS_U token

### DIFF
--- a/qeutil/qeio.py
+++ b/qeutil/qeio.py
@@ -850,7 +850,10 @@ def get_xc_xml(tree, mydict):
     element = tree.find("EXCHANGE_CORRELATION")
 
     mydict['DFT'] = element.find("DFT").text
-    subel = element.find("LDA_PLUS_U_CALCULATION").text.strip()
+    subel = element.find("LDA_PLUS_U_CALCULATION")
+   
+   if subel is not None:   # in some cases, the LDA token is not found
+      subel = subel.text.strip()
     
     if subel == 'T':
         


### PR DESCRIPTION
In some cases, the data-file.xml does not contain the DFT/LDA_PLUS_U token.
I thus added a test for token to exist (not None).