### PR TITLE
qeio: handle warning message in atom forces block

### DIFF
--- a/qeutil/qeio.py
+++ b/qeutil/qeio.py
@@ -236,7 +236,7 @@ def read_quantumespresso_textoutput(filename, verbose=False):
                 CAUGHT_LINES = []
             
             if l.rfind('forces acting on atoms') > -1:                  # find forces acting on atoms
-                CAUGHT = Results['nat']
+                CAUGHT = Results['nat']+3                               # sometimes, warning 'negative rho' shifts forces
                 CAUGHT_DISCARD = 1
                 CAUGHT_WHAT = 'forces'
                 CAUGHT_LINES = []
@@ -295,7 +295,9 @@ def read_quantumespresso_textoutput(filename, verbose=False):
                 Results['atoms_forces'] = []
                 number = len(CAUGHT_LINES)
                 for n in range(number):
-                    Results['atoms_forces'].append([float(get_number(el)) for el in CAUGHT_LINES[n].split()[6:9]])
+                    if len(CAUGHT_LINES[n].split()):
+                        if CAUGHT_LINES[n].split()[0].startswith('atom'):  # make sure we have an 'atom' line
+                            Results['atoms_forces'].append([float(get_number(el)) for el in CAUGHT_LINES[n].split()[6:9]])
 
                 # elif (CAUGHT_WHAT == 'old cell'):
                 #     old_cell = []


### PR DESCRIPTION
Hi Pawel,

Sometimes, the forces block has an additional warning 'negative rho' which shifts forces. 
Then we should scan more lines and pass the warning in qeio. That's why there is a starts with 'atoms' test.
Otherwise we would get empty list elements which then produce an error later when converting:

- 'atom_forces' into 'forces'

 for the calculator implemented properties..